### PR TITLE
Merge v2.0.1 into `stable`

### DIFF
--- a/Modding/ModLoader.cs
+++ b/Modding/ModLoader.cs
@@ -112,7 +112,7 @@ namespace Godot.Modding
             // Invoke all static methods annotated with [Startup] along with the supplied parameters (if any)
             mod.Assemblies
                 .SelectMany(assembly => assembly.GetTypes())
-                .SelectMany(type => type.GetMethods(BindingFlags.NonPublic | BindingFlags.Public))
+                .SelectMany(type => type.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
                 .Select(method => (method, method.GetCustomAttribute<ModStartupAttribute>()))
                 .Where(pair => pair.Item2 is not null)
                 .ForEach(pair => pair.Item1.Invoke(null, pair.Item2.Parameters));

--- a/Modot.csproj
+++ b/Modot.csproj
@@ -8,7 +8,7 @@
         <!-- Workaround as Godot does not know how to properly load NuGet packages -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.0.0</PackageVersion>
+        <PackageVersion>2.0.1</PackageVersion>
         <Title>Modot</Title>
         <Authors>Carnagion</Authors>
         <Description>A mod loader and API for applications made using Godot, with the ability to load C# assemblies, XML data, and resource packs at runtime.</Description>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A more detailed explanation of all features along with instructions on usage is 
 Simply include the following lines in a Godot project's `.csproj` file (either by editing the file manually or letting an IDE install the package):
 ```xml
 <ItemGroup>
-    <PackageReference Include="Modot" Version="2.0.0"/>
+    <PackageReference Include="Modot" Version="2.0.1"/>
 </ItemGroup>
  ```
 


### PR DESCRIPTION
# Bugfixes
- `ModLoader.StartupMod(Mod)` now actually retrieves all static methods in an assembly